### PR TITLE
For test assertions, use library methods over Java assert.

### DIFF
--- a/jvm/src/test/java/com/nawforce/apexparser/ApexLexerTest.java
+++ b/jvm/src/test/java/com/nawforce/apexparser/ApexLexerTest.java
@@ -1,6 +1,6 @@
 package com.nawforce.apexparser;
 
-import org.antlr.v4.runtime.ANTLRInputStream;
+import org.antlr.v4.runtime.CharStreams;
 import org.antlr.v4.runtime.CommonTokenStream;
 import org.junit.jupiter.api.Test;
 
@@ -13,7 +13,7 @@ public class ApexLexerTest {
 
     @Test
     void testLexerGeneratesTokens() {
-        ApexLexer lexer = new ApexLexer(new ANTLRInputStream("public class Hello {}"));
+        ApexLexer lexer = new ApexLexer(CharStreams.fromString("public class Hello {}"));
         CommonTokenStream tokens  = new CommonTokenStream(lexer);
         assertEquals(6, tokens.getNumberOfOnChannelTokens());
     }

--- a/jvm/src/test/java/com/nawforce/apexparser/ApexListenerTest.java
+++ b/jvm/src/test/java/com/nawforce/apexparser/ApexListenerTest.java
@@ -7,6 +7,8 @@ import org.junit.jupiter.api.Test;
 import java.io.IOException;
 import java.io.StringReader;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
 public class ApexListenerTest {
 
     static class TestListener extends ApexParserBaseListener {
@@ -30,7 +32,7 @@ public class ApexListenerTest {
         TestListener listener = new TestListener();
         ParseTreeWalker.DEFAULT.walk(listener, context);
 
-        assert(1 == listener.methodCount);
+        assertEquals(listener.methodCount.intValue(), 1);
     }
 
 }

--- a/jvm/src/test/java/com/nawforce/apexparser/ApexParserTest.java
+++ b/jvm/src/test/java/com/nawforce/apexparser/ApexParserTest.java
@@ -8,6 +8,7 @@ import java.io.StringReader;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class ApexParserTest {
 
@@ -26,7 +27,7 @@ public class ApexParserTest {
         CommonTokenStream tokens = new CommonTokenStream(lexer);
         ApexParser parser = new ApexParser(tokens);
         ApexParser.ExpressionContext context = parser.expression();
-        assert (context instanceof ApexParser.Arth1ExpressionContext);
+        assertTrue(context instanceof ApexParser.Arth1ExpressionContext);
         assertEquals(2, ((ApexParser.Arth1ExpressionContext) context).expression().size());
     }
 

--- a/jvm/src/test/java/com/nawforce/apexparser/ApexVisitorTest.java
+++ b/jvm/src/test/java/com/nawforce/apexparser/ApexVisitorTest.java
@@ -6,6 +6,8 @@ import org.junit.jupiter.api.Test;
 import java.io.IOException;
 import java.io.StringReader;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
 public class ApexVisitorTest {
 
     static class TestVisitor extends ApexParserBaseVisitor<Integer> {
@@ -34,7 +36,7 @@ public class ApexVisitorTest {
         TestVisitor visitor = new TestVisitor();
         visitor.visit(context);
 
-        assert (1 == visitor.methodCount);
+        assertEquals(visitor.methodCount.intValue(), 1);
     }
 
 }


### PR DESCRIPTION
Replaced 3 instances of assert.