### PR TITLE
Fix lexer rules for Currency and DateTime literals

### DIFF
--- a/antlr/ApexLexer.g4
+++ b/antlr/ApexLexer.g4
@@ -222,6 +222,10 @@ LAST_N_FISCAL_YEARS_N     : 'last_n_fiscal_years';
 DateLiteral: Digit Digit Digit Digit '-' Digit Digit '-' Digit Digit;
 DateTimeLiteral: DateLiteral 't' Digit Digit ':' Digit Digit ':' Digit Digit ('z' | (('+' | '-') Digit+ ( ':' Digit+)? ));
 
+// SOQL Currency literal
+// (NOTE: this is also a valid Identifier)
+CurrencyLiteral: [a-z] [a-z] [a-z] Digit+;
+
 // SOSL Keywords
 FIND                      : 'find';
 EMAIL                     : 'email';

--- a/antlr/ApexLexer.g4
+++ b/antlr/ApexLexer.g4
@@ -224,7 +224,8 @@ DateTimeLiteral: DateLiteral 't' Digit Digit ':' Digit Digit ':' Digit Digit ('z
 
 // SOQL Currency literal
 // (NOTE: this is also a valid Identifier)
-CurrencyLiteral: [a-z] [a-z] [a-z] Digit+;
+IntegralCurrencyLiteral: [a-z] [a-z] [a-z] Digit+;
+FractionalCurrencyLiteral: [a-z] [a-z] [a-z] Digit+ '.' Digit*;
 
 // SOSL Keywords
 FIND                      : 'find';

--- a/antlr/ApexLexer.g4
+++ b/antlr/ApexLexer.g4
@@ -220,7 +220,7 @@ LAST_N_FISCAL_YEARS_N     : 'last_n_fiscal_years';
 
 // SOQL Date literal
 DateLiteral: Digit Digit Digit Digit '-' Digit Digit '-' Digit Digit;
-DateTimeLiteral: DateLiteral 'T' Digit Digit ':' Digit Digit ':' Digit Digit ('Z' | (('+' | '-') Digit+ ( ':' Digit+)? ));
+DateTimeLiteral: DateLiteral 't' Digit Digit ':' Digit Digit ':' Digit Digit ('z' | (('+' | '-') Digit+ ( ':' Digit+)? ));
 
 // SOSL Keywords
 FIND                      : 'find';

--- a/antlr/ApexParser.g4
+++ b/antlr/ApexParser.g4
@@ -657,7 +657,7 @@ value
     | DateLiteral
     | DateTimeLiteral
     | dateFormula
-    | currencyValue
+    | CurrencyLiteral
     | LPAREN subQuery RPAREN
     | valueList
     | boundExpression
@@ -665,8 +665,6 @@ value
 
 valueList
     : LPAREN value (COMMA value)* RPAREN;
-
-currencyValue: soqlId signedInteger;
 
 withClause
     : WITH DATA CATEGORY filteringExpression
@@ -827,6 +825,7 @@ soslId
 // can significantly impact the parser performance by creating ambiguities.
 id
     : Identifier
+    | CurrencyLiteral
     | AFTER
     | BEFORE
     | GET

--- a/antlr/ApexParser.g4
+++ b/antlr/ApexParser.g4
@@ -657,7 +657,8 @@ value
     | DateLiteral
     | DateTimeLiteral
     | dateFormula
-    | CurrencyLiteral
+    | IntegralCurrencyLiteral
+    | FractionalCurrencyLiteral
     | LPAREN subQuery RPAREN
     | valueList
     | boundExpression
@@ -825,7 +826,6 @@ soslId
 // can significantly impact the parser performance by creating ambiguities.
 id
     : Identifier
-    | CurrencyLiteral
     | AFTER
     | BEFORE
     | GET
@@ -839,6 +839,8 @@ id
     | WHEN
     | WITH
     | WITHOUT
+    // SOQL Values
+    | IntegralCurrencyLiteral
     // SOQL Specific Keywords
     | SELECT
     | COUNT
@@ -1021,6 +1023,8 @@ anyId
     | WHILE
     | WITH
     | WITHOUT
+    // SOQL Values
+    | IntegralCurrencyLiteral
     // SOQL Specific Keywords
     | SELECT
     | COUNT

--- a/jvm/src/test/java/com/nawforce/apexparser/ApexParserTest.java
+++ b/jvm/src/test/java/com/nawforce/apexparser/ApexParserTest.java
@@ -123,6 +123,18 @@ public class ApexParserTest {
     }
 
     @Test
+    void testCurrencyLiteral() throws IOException {
+        ApexLexer lexer = new ApexLexer(new CaseInsensitiveInputStream(new StringReader(
+             "SELECT Id FROM Account WHERE Amount > USD100")));
+        CommonTokenStream tokens = new CommonTokenStream(lexer);
+        ApexParser parser = new ApexParser(tokens);
+        SyntaxErrorCounter errorCounter = new SyntaxErrorCounter();
+        parser.addErrorListener(errorCounter);
+        ApexParser.QueryContext context = parser.query();
+        assertEquals(errorCounter.getNumErrors(), 0);
+    }
+
+    @Test
     void testDateTimeLiteral() throws IOException {
         ApexLexer lexer = new ApexLexer(new CaseInsensitiveInputStream(new StringReader(
              "SELECT Name, (SELECT Id FROM Account WHERE createdDate > 2020-01-01T12:00:00Z) FROM Opportunity")));

--- a/jvm/src/test/java/com/nawforce/apexparser/ApexParserTest.java
+++ b/jvm/src/test/java/com/nawforce/apexparser/ApexParserTest.java
@@ -125,7 +125,7 @@ public class ApexParserTest {
     @Test
     void testCurrencyLiteral() throws IOException {
         ApexLexer lexer = new ApexLexer(new CaseInsensitiveInputStream(new StringReader(
-             "SELECT Id FROM Account WHERE Amount > USD100")));
+             "SELECT Id FROM Account WHERE Amount > USD100.01 AND Amount < USD200")));
         CommonTokenStream tokens = new CommonTokenStream(lexer);
         ApexParser parser = new ApexParser(tokens);
         SyntaxErrorCounter errorCounter = new SyntaxErrorCounter();

--- a/jvm/src/test/java/com/nawforce/apexparser/ApexParserTest.java
+++ b/jvm/src/test/java/com/nawforce/apexparser/ApexParserTest.java
@@ -1,6 +1,9 @@
 package com.nawforce.apexparser;
 
+import org.antlr.v4.runtime.BaseErrorListener;
 import org.antlr.v4.runtime.CommonTokenStream;
+import org.antlr.v4.runtime.Recognizer;
+import org.antlr.v4.runtime.RecognitionException;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
@@ -11,6 +14,25 @@ import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class ApexParserTest {
+
+    public static class SyntaxErrorCounter extends BaseErrorListener {
+        private int numErrors = 0;
+
+        @Override
+        public void syntaxError(
+                Recognizer<?, ?> recognizer,
+                Object offendingSymbol,
+                int line,
+                int charPositionInLine,
+                String msg,
+                RecognitionException e) {
+            this.numErrors += 1;
+        }
+
+        public int getNumErrors() {
+            return this.numErrors;
+        }
+    }
 
     @Test
     void testBooleanLiteral() throws IOException {
@@ -98,6 +120,18 @@ public class ApexParserTest {
         ApexParser parser = new ApexParser(tokens);
         ApexParser.SoslLiteralContext context = parser.soslLiteral();
         assertNotEquals(null, context);
+    }
+
+    @Test
+    void testDateTimeLiteral() throws IOException {
+        ApexLexer lexer = new ApexLexer(new CaseInsensitiveInputStream(new StringReader(
+             "SELECT Name, (SELECT Id FROM Account WHERE createdDate > 2020-01-01T12:00:00Z) FROM Opportunity")));
+        CommonTokenStream tokens = new CommonTokenStream(lexer);
+        ApexParser parser = new ApexParser(tokens);
+        SyntaxErrorCounter errorCounter = new SyntaxErrorCounter();
+        parser.addErrorListener(errorCounter);
+        ApexParser.QueryContext context = parser.query();
+        assertEquals(errorCounter.getNumErrors(), 0);
     }
 }
 


### PR DESCRIPTION
This fixes (the only) 2 mis-parses on our (large) Apex codebase.