### PR TITLE
Fix corner case where fractional currency token (without decimal digits) absorbs dot in dotExpression rule

### DIFF
--- a/antlr/ApexLexer.g4
+++ b/antlr/ApexLexer.g4
@@ -225,7 +225,6 @@ DateTimeLiteral: DateLiteral 't' Digit Digit ':' Digit Digit ':' Digit Digit ('z
 // SOQL Currency literal
 // (NOTE: this is also a valid Identifier)
 IntegralCurrencyLiteral: [a-z] [a-z] [a-z] Digit+;
-FractionalCurrencyLiteral: [a-z] [a-z] [a-z] Digit+ '.' Digit*;
 
 // SOSL Keywords
 FIND                      : 'find';

--- a/antlr/ApexParser.g4
+++ b/antlr/ApexParser.g4
@@ -657,8 +657,7 @@ value
     | DateLiteral
     | DateTimeLiteral
     | dateFormula
-    | IntegralCurrencyLiteral
-    | FractionalCurrencyLiteral
+    | IntegralCurrencyLiteral (DOT IntegerLiteral?)?
     | LPAREN subQuery RPAREN
     | valueList
     | boundExpression

--- a/jvm/src/test/java/com/nawforce/apexparser/ApexListenerTest.java
+++ b/jvm/src/test/java/com/nawforce/apexparser/ApexListenerTest.java
@@ -32,7 +32,7 @@ public class ApexListenerTest {
         TestListener listener = new TestListener();
         ParseTreeWalker.DEFAULT.walk(listener, context);
 
-        assertEquals(listener.methodCount.intValue(), 1);
+        assertEquals(1, listener.methodCount.intValue());
     }
 
 }

--- a/jvm/src/test/java/com/nawforce/apexparser/ApexParserTest.java
+++ b/jvm/src/test/java/com/nawforce/apexparser/ApexParserTest.java
@@ -135,6 +135,18 @@ public class ApexParserTest {
     }
 
     @Test
+    void testIdentifiersThatCouldBeCurrencyLiterals() throws IOException {
+        ApexLexer lexer = new ApexLexer(new CaseInsensitiveInputStream(new StringReader(
+             "USD100.name = 'name';")));
+        CommonTokenStream tokens = new CommonTokenStream(lexer);
+        ApexParser parser = new ApexParser(tokens);
+        SyntaxErrorCounter errorCounter = new SyntaxErrorCounter();
+        parser.addErrorListener(errorCounter);
+        ApexParser.StatementContext context = parser.statement();
+        assertEquals(0, errorCounter.getNumErrors());
+    }
+
+    @Test
     void testDateTimeLiteral() throws IOException {
         ApexLexer lexer = new ApexLexer(new CaseInsensitiveInputStream(new StringReader(
              "SELECT Name, (SELECT Id FROM Account WHERE createdDate > 2020-01-01T12:00:00Z) FROM Opportunity")));

--- a/jvm/src/test/java/com/nawforce/apexparser/ApexParserTest.java
+++ b/jvm/src/test/java/com/nawforce/apexparser/ApexParserTest.java
@@ -130,8 +130,8 @@ public class ApexParserTest {
         ApexParser parser = new ApexParser(tokens);
         SyntaxErrorCounter errorCounter = new SyntaxErrorCounter();
         parser.addErrorListener(errorCounter);
-        ApexParser.QueryContext context = parser.query();
-        assertEquals(errorCounter.getNumErrors(), 0);
+        parser.query();
+        assertEquals(0, errorCounter.getNumErrors());
     }
 
     @Test
@@ -142,7 +142,7 @@ public class ApexParserTest {
         ApexParser parser = new ApexParser(tokens);
         SyntaxErrorCounter errorCounter = new SyntaxErrorCounter();
         parser.addErrorListener(errorCounter);
-        ApexParser.StatementContext context = parser.statement();
+        parser.statement();
         assertEquals(0, errorCounter.getNumErrors());
     }
 
@@ -154,8 +154,8 @@ public class ApexParserTest {
         ApexParser parser = new ApexParser(tokens);
         SyntaxErrorCounter errorCounter = new SyntaxErrorCounter();
         parser.addErrorListener(errorCounter);
-        ApexParser.QueryContext context = parser.query();
-        assertEquals(errorCounter.getNumErrors(), 0);
+        parser.query();
+        assertEquals(0, errorCounter.getNumErrors());
     }
 }
 

--- a/jvm/src/test/java/com/nawforce/apexparser/ApexVisitorTest.java
+++ b/jvm/src/test/java/com/nawforce/apexparser/ApexVisitorTest.java
@@ -36,7 +36,7 @@ public class ApexVisitorTest {
         TestVisitor visitor = new TestVisitor();
         visitor.visit(context);
 
-        assertEquals(visitor.methodCount.intValue(), 1);
+        assertEquals(1, visitor.methodCount.intValue());
     }
 
 }


### PR DESCRIPTION
Found an example of this when integrating 2.12.0.

Also cleaned up some unrelated linter issues.