### PR TITLE
Allow semicolons as `for` and `while` loop bodies

### DIFF
--- a/antlr/ApexParser.g4
+++ b/antlr/ApexParser.g4
@@ -308,11 +308,11 @@ whenLiteral
     ;
 
 forStatement
-    : FOR LPAREN forControl RPAREN statement
+    : FOR LPAREN forControl RPAREN (statement | SEMI)
     ;
 
 whileStatement
-    : WHILE parExpression statement
+    : WHILE parExpression (statement | SEMI)
     ;
 
 doWhileStatement

--- a/jvm/src/test/java/com/nawforce/apexparser/ApexParserTest.java
+++ b/jvm/src/test/java/com/nawforce/apexparser/ApexParserTest.java
@@ -170,6 +170,41 @@ public class ApexParserTest {
         assertEquals(0, errorCounter.getNumErrors());
     }
 
+    @Test
+    void testSemiAllowedAsWhileBody() throws IOException {
+        ApexLexer lexer = new ApexLexer(new CaseInsensitiveInputStream(new StringReader(
+                "while (x++ < 10 && !(y-- < 0));")));
+        CommonTokenStream tokens = new CommonTokenStream(lexer);
+        ApexParser parser = new ApexParser(tokens);
+        SyntaxErrorCounter errorCounter = new SyntaxErrorCounter();
+        parser.addErrorListener(errorCounter);
+        parser.statement();
+        assertEquals(0, errorCounter.getNumErrors());
+    }
+
+    @Test
+    void testSemiAllowedAsForBody() throws IOException {
+        ApexLexer lexer = new ApexLexer(new CaseInsensitiveInputStream(new StringReader(
+                "for(x=0; x<10; x++);")));
+        CommonTokenStream tokens = new CommonTokenStream(lexer);
+        ApexParser parser = new ApexParser(tokens);
+        SyntaxErrorCounter errorCounter = new SyntaxErrorCounter();
+        parser.addErrorListener(errorCounter);
+        parser.statement();
+        assertEquals(0, errorCounter.getNumErrors());
+    }
+
+    @Test
+    void testSemiDisallowedAsGeneralStatement() throws IOException {
+        ApexLexer lexer = new ApexLexer(new CaseInsensitiveInputStream(new StringReader(
+                "if (x == 3); else { ; }")));
+        CommonTokenStream tokens = new CommonTokenStream(lexer);
+        ApexParser parser = new ApexParser(tokens);
+        SyntaxErrorCounter errorCounter = new SyntaxErrorCounter();
+        parser.addErrorListener(errorCounter);
+        parser.statement();
+        assertEquals(1, errorCounter.getNumErrors());
+    }
 }
 
 


### PR DESCRIPTION
Salesforce accepts the following statements, for example:

```
for(x = 0; x<10; x*=2);
while (x++ < 10 && !(x-- < 0));
```

Added unit tests of accepted and error syntax. Validated new grammar against large codebase.