### PR TITLE
Tolerate parenthesis pairs around (each) `when` clause literal.

### DIFF
--- a/antlr/ApexParser.g4
+++ b/antlr/ApexParser.g4
@@ -305,6 +305,9 @@ whenLiteral
     | StringLiteral
     | NULL
     | id
+    // Salesforce tolerates paren pairs around each literal,
+    // although this is not explicitly documented.
+    | LPAREN whenLiteral RPAREN
     ;
 
 forStatement

--- a/jvm/src/test/java/com/nawforce/apexparser/ApexParserTest.java
+++ b/jvm/src/test/java/com/nawforce/apexparser/ApexParserTest.java
@@ -170,6 +170,22 @@ public class ApexParserTest {
         assertEquals(0, errorCounter.getNumErrors());
     }
 
+    @Test
+    void testWhenLiteralParens() throws IOException {
+        ApexLexer lexer = new ApexLexer(new CaseInsensitiveInputStream(new StringReader(
+                "switch on (x) { \n" +
+                "  when 1 { return 1; } \n" +
+                "  when ((2)) { return 2; } \n" +
+                "  when (3), (4) { return 3; } \n" +
+                "}")));
+        CommonTokenStream tokens = new CommonTokenStream(lexer);
+        ApexParser parser = new ApexParser(tokens);
+        SyntaxErrorCounter errorCounter = new SyntaxErrorCounter();
+        parser.addErrorListener(errorCounter);
+        parser.statement();
+        assertEquals(0, errorCounter.getNumErrors());
+    }
+
 }
 
 


### PR DESCRIPTION
Salesforce tolerates parenthesis pairs around (each) `when` clause literal.

Although this isn't explicitly mentioned in the Apex language documentation, these cases were empirically tested.

Add unit test of various cases.