### PR TITLE
Fix wrong quoting characters for SOSL FIND queries

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,13 @@ import 'CommonTokenStream' & 'ParseTreeWalker' from 'apex-parser' instead of fro
     import { CommonTokenStream} from "apex-parser";
     import { ParseTreeWalker } from "apex-parser";
 
+### SOSL FIND quoting
+SOSL FIND uses ' as a quoting character when embedded in Apex, in the API braces are used:
+
+    Find {something} RETURNING Account
+
+To parse the API format there is an alternative parser rule, soslLiteralAlt, that you can use instead of soslLiteral. See SOSLParserTest for some examples of how these differ.
+
 ### Packages
 
 Maven

--- a/antlr/ApexLexer.g4
+++ b/antlr/ApexLexer.g4
@@ -243,7 +243,7 @@ RETURNING                 : 'returning';
 LISTVIEW                  : 'listview';
 
 FindLiteral
-    :   '[' WS? 'find' WS '{' FindCharacters? '}'
+    :   '[' WS? 'find' WS '\'' FindCharacters? '\''
     ;
 
 fragment
@@ -253,6 +253,21 @@ FindCharacters
 
 fragment
 FindCharacter
+    :   ~['\\]
+    |   FindEscapeSequence
+    ;
+
+FindLiteralAlt
+    :   '[' WS? 'find' WS '{' FindCharactersAlt? '}'
+    ;
+
+fragment
+FindCharactersAlt
+    :   FindCharacterAlt+
+    ;
+
+fragment
+FindCharacterAlt
     :   ~[}\\]
     |   FindEscapeSequence
     ;

--- a/antlr/ApexParser.g4
+++ b/antlr/ApexParser.g4
@@ -773,6 +773,10 @@ soslLiteral
     | LBRACK FIND boundExpression soslClauses RBRACK
     ;
 
+soslLiteralAlt
+    : FindLiteralAlt soslClauses RBRACK
+    ;
+
 soslClauses
     : (IN searchGroup)?
       (RETURNING fieldSpecList)?

--- a/jvm/src/test/java/com/nawforce/apexparser/ApexParserTest.java
+++ b/jvm/src/test/java/com/nawforce/apexparser/ApexParserTest.java
@@ -1,44 +1,13 @@
 package com.nawforce.apexparser;
 
-import org.antlr.v4.runtime.*;
 import org.junit.jupiter.api.Test;
 
 import javafx.util.Pair;
 
+import static com.nawforce.apexparser.SyntaxErrorCounter.createParser;
 import static org.junit.jupiter.api.Assertions.*;
 
 public class ApexParserTest {
-
-    public static class SyntaxErrorCounter extends BaseErrorListener {
-        private int numErrors = 0;
-
-        @Override
-        public void syntaxError(
-                Recognizer<?, ?> recognizer,
-                Object offendingSymbol,
-                int line,
-                int charPositionInLine,
-                String msg,
-                RecognitionException e) {
-            this.numErrors += 1;
-        }
-
-        public int getNumErrors() {
-            return this.numErrors;
-        }
-    }
-
-    Pair<ApexParser, SyntaxErrorCounter> createParser(String input) {
-        ApexLexer lexer = new ApexLexer(new CaseInsensitiveInputStream(CharStreams.fromString(input)));
-        CommonTokenStream tokens = new CommonTokenStream(lexer);
-        ApexParser parser = new ApexParser(tokens);
-
-        parser.removeErrorListeners();
-        SyntaxErrorCounter errorCounter = new SyntaxErrorCounter();
-        parser.addErrorListener(errorCounter);
-
-        return new Pair<>(parser, errorCounter);
-    }
 
     @Test
     void testBooleanLiteral() {
@@ -107,14 +76,6 @@ public class ApexParserTest {
     void testSOQL() {
         Pair<ApexParser, SyntaxErrorCounter> parserAndCounter = createParser("Select Fields(All) from Account");
         ApexParser.QueryContext context = parserAndCounter.getKey().query();
-        assertNotNull(context);
-        assertEquals(0, parserAndCounter.getValue().getNumErrors());
-    }
-
-    @Test
-    void testSOSL() {
-        Pair<ApexParser, SyntaxErrorCounter> parserAndCounter = createParser("[Find {something} RETURNING Account]");
-        ApexParser.SoslLiteralContext context = parserAndCounter.getKey().soslLiteral();
         assertNotNull(context);
         assertEquals(0, parserAndCounter.getValue().getNumErrors());
     }

--- a/jvm/src/test/java/com/nawforce/apexparser/SOSLParserTest.java
+++ b/jvm/src/test/java/com/nawforce/apexparser/SOSLParserTest.java
@@ -1,0 +1,50 @@
+package com.nawforce.apexparser;
+
+import org.junit.jupiter.api.Test;
+
+import javafx.util.Pair;
+
+import static com.nawforce.apexparser.SyntaxErrorCounter.createParser;
+import static org.junit.jupiter.api.Assertions.*;
+
+public class SOSLParserTest {
+    @Test
+    void testBasicQuery() {
+        Pair<ApexParser, SyntaxErrorCounter> parserAndCounter = createParser("[Find 'something' RETURNING Account]");
+        ApexParser.SoslLiteralContext context = parserAndCounter.getKey().soslLiteral();
+        assertNotNull(context);
+        assertEquals(0, parserAndCounter.getValue().getNumErrors());
+    }
+
+    @Test
+    void testEmbeddedQuote() {
+        Pair<ApexParser, SyntaxErrorCounter> parserAndCounter = createParser("[Find 'some\\'thing' RETURNING Account]");
+        ApexParser.SoslLiteralContext context = parserAndCounter.getKey().soslLiteral();
+        assertNotNull(context);
+        assertEquals(0, parserAndCounter.getValue().getNumErrors());
+    }
+
+    @Test
+    void testBracesFail() {
+        Pair<ApexParser, SyntaxErrorCounter> parserAndCounter = createParser("[Find {something} RETURNING Account]");
+        ApexParser.SoslLiteralContext context = parserAndCounter.getKey().soslLiteral();
+        assertNotNull(context);
+        assertEquals(1, parserAndCounter.getValue().getNumErrors());
+    }
+
+    @Test
+    void testBracesOnAltFormat() {
+        Pair<ApexParser, SyntaxErrorCounter> parserAndCounter = createParser("[Find {something} RETURNING Account]");
+        ApexParser.SoslLiteralAltContext context = parserAndCounter.getKey().soslLiteralAlt();
+        assertNotNull(context);
+        assertEquals(0, parserAndCounter.getValue().getNumErrors());
+    }
+
+    @Test
+    void testQuotesFailOnAltFormat() {
+        Pair<ApexParser, SyntaxErrorCounter> parserAndCounter = createParser("[Find 'something' RETURNING Account]");
+        ApexParser.SoslLiteralAltContext context = parserAndCounter.getKey().soslLiteralAlt();
+        assertNotNull(context);
+        assertEquals(1, parserAndCounter.getValue().getNumErrors());
+    }
+}

--- a/jvm/src/test/java/com/nawforce/apexparser/SyntaxErrorCounter.java
+++ b/jvm/src/test/java/com/nawforce/apexparser/SyntaxErrorCounter.java
@@ -1,0 +1,35 @@
+package com.nawforce.apexparser;
+
+import javafx.util.Pair;
+import org.antlr.v4.runtime.*;
+
+public class SyntaxErrorCounter extends BaseErrorListener {
+    private int numErrors = 0;
+
+    @Override
+    public void syntaxError(
+            Recognizer<?, ?> recognizer,
+            Object offendingSymbol,
+            int line,
+            int charPositionInLine,
+            String msg,
+            RecognitionException e) {
+        this.numErrors += 1;
+    }
+
+    public int getNumErrors() {
+        return this.numErrors;
+    }
+
+    public static Pair<ApexParser, SyntaxErrorCounter> createParser(String input) {
+        ApexLexer lexer = new ApexLexer(new CaseInsensitiveInputStream(CharStreams.fromString(input)));
+        CommonTokenStream tokens = new CommonTokenStream(lexer);
+        ApexParser parser = new ApexParser(tokens);
+
+        parser.removeErrorListeners();
+        SyntaxErrorCounter errorCounter = new SyntaxErrorCounter();
+        parser.addErrorListener(errorCounter);
+
+        return new Pair<>(parser, errorCounter);
+    }
+}

--- a/npm/jestconfig.json
+++ b/npm/jestconfig.json
@@ -1,7 +1,14 @@
 {
-    "transform": {
-      "^.+\\.jsx?$": "babel-jest"
-    },
-    "testRegex": "(/__tests__/.*|(\\.|/)(test|spec))\\.(jsx?)$",
-    "moduleFileExtensions": ["ts", "tsx", "js", "jsx", "json", "node"]
-  }
+  "transform": {
+    "^.+\\.jsx?$": "babel-jest"
+  },
+  "testRegex": "/__tests__/.*Test.js$",
+  "moduleFileExtensions": [
+    "ts",
+    "tsx",
+    "js",
+    "jsx",
+    "json",
+    "node"
+  ]
+}

--- a/npm/src/__tests__/ApexParserTest.ts
+++ b/npm/src/__tests__/ApexParserTest.ts
@@ -1,37 +1,9 @@
-import { ApexLexer } from "../ApexLexer";
 import {
-    ApexParser, LiteralContext, Arth1ExpressionContext, CompilationUnitContext,
-    QueryContext, SoslLiteralContext, StatementContext, TriggerUnitContext
+    LiteralContext, Arth1ExpressionContext, CompilationUnitContext,
+    QueryContext, StatementContext, TriggerUnitContext
 } from "../ApexParser";
-import { CaseInsensitiveInputStream } from "../CaseInsensitiveInputStream"
-import { ANTLRErrorListener, CommonTokenStream, RecognitionException, Recognizer, Token } from 'antlr4ts';
 import { ThrowingErrorListener, SyntaxException } from "../ThrowingErrorListener";
-
-class SyntaxErrorCounter implements ANTLRErrorListener<Token> {
-    numErrors = 0
-
-    syntaxError(recognizer: Recognizer<Token, any>,
-        offendingSymbol: Token, line: number, charPositionInLine: number, msg: string,
-        e: RecognitionException | undefined): any {
-        this.numErrors += 1;
-    }
-
-    getNumErrors(): number {
-        return this.numErrors;
-    }
-}
-
-function createParser(userData: string, input: string): [ApexParser, SyntaxErrorCounter] {
-    const lexer = new ApexLexer(new CaseInsensitiveInputStream(userData, input))
-    const tokens = new CommonTokenStream(lexer);
-    const parser = new ApexParser(tokens)
-
-    parser.removeErrorListeners()
-    const errorCounter = new SyntaxErrorCounter();
-    parser.addErrorListener(errorCounter);
-
-    return [parser, errorCounter];
-}
+import { createParser } from "./SyntaxErrorCounter";
 
 test('Boolean Literal', () => {
 
@@ -133,15 +105,6 @@ test('SOQL Query Using Field function', () => {
     const context = parser.query()
 
     expect(context).toBeInstanceOf(QueryContext)
-    expect(errorCounter.getNumErrors()).toEqual(0)
-})
-
-test('SOSL Query', () => {
-    const [parser, errorCounter] = createParser("test.sosl", "[Find {something} RETURNING Account]")
-
-    const context = parser.soslLiteral()
-
-    expect(context).toBeInstanceOf(SoslLiteralContext)
     expect(errorCounter.getNumErrors()).toEqual(0)
 })
 

--- a/npm/src/__tests__/SOSLParserTest.ts
+++ b/npm/src/__tests__/SOSLParserTest.ts
@@ -1,0 +1,50 @@
+import {
+    SoslLiteralAltContext,
+    SoslLiteralContext
+} from "../ApexParser";
+import { createParser } from "./SyntaxErrorCounter";
+
+test('testBasicQuery', () => {
+    const [parser, errorCounter] = createParser("test.sosl", "[Find 'something' RETURNING Account]")
+
+    const context = parser.soslLiteral()
+
+    expect(context).toBeInstanceOf(SoslLiteralContext)
+    expect(errorCounter.getNumErrors()).toEqual(0)
+})
+
+test('testEmbeddedQuote', () => {
+    const [parser, errorCounter] = createParser("test.sosl", "[Find 'some\\'thing' RETURNING Account]")
+
+    const context = parser.soslLiteral()
+
+    expect(context).toBeInstanceOf(SoslLiteralContext)
+    expect(errorCounter.getNumErrors()).toEqual(0)
+})
+
+test('testBracesFail', () => {
+    const [parser, errorCounter] = createParser("test.sosl", "[Find {something} RETURNING Account]")
+
+    const context = parser.soslLiteral()
+
+    expect(context).toBeInstanceOf(SoslLiteralContext)
+    expect(errorCounter.getNumErrors()).toEqual(1)
+})
+
+test('testBracesOnAltFormat', () => {
+    const [parser, errorCounter] = createParser("test.sosl", "[Find {something} RETURNING Account]")
+
+    const context = parser.soslLiteralAlt()
+
+    expect(context).toBeInstanceOf(SoslLiteralAltContext)
+    expect(errorCounter.getNumErrors()).toEqual(0)
+})
+
+test('testQuotesFailOnAltFormat', () => {
+    const [parser, errorCounter] = createParser("test.sosl", "[Find 'something' RETURNING Account]")
+
+    const context = parser.soslLiteralAlt()
+
+    expect(context).toBeInstanceOf(SoslLiteralAltContext)
+    expect(errorCounter.getNumErrors()).toEqual(1)
+})

--- a/npm/src/__tests__/SyntaxErrorCounter.ts
+++ b/npm/src/__tests__/SyntaxErrorCounter.ts
@@ -1,0 +1,30 @@
+import { ANTLRErrorListener, CommonTokenStream, RecognitionException, Recognizer, Token } from "antlr4ts";
+import { ApexLexer } from "../ApexLexer";
+import { ApexParser } from "../ApexParser";
+import { CaseInsensitiveInputStream } from "../CaseInsensitiveInputStream";
+
+export class SyntaxErrorCounter implements ANTLRErrorListener<Token> {
+    numErrors = 0
+
+    syntaxError(recognizer: Recognizer<Token, any>,
+        offendingSymbol: Token, line: number, charPositionInLine: number, msg: string,
+        e: RecognitionException | undefined): any {
+        this.numErrors += 1;
+    }
+
+    getNumErrors(): number {
+        return this.numErrors;
+    }
+}
+
+export function createParser(userData: string, input: string): [ApexParser, SyntaxErrorCounter] {
+    const lexer = new ApexLexer(new CaseInsensitiveInputStream(userData, input))
+    const tokens = new CommonTokenStream(lexer);
+    const parser = new ApexParser(tokens)
+
+    parser.removeErrorListeners()
+    const errorCounter = new SyntaxErrorCounter();
+    parser.addErrorListener(errorCounter);
+
+    return [parser, errorCounter];
+}


### PR DESCRIPTION

This changes the FIND string delimiter to '.  See README for how to use { } to quote the search string.