### PR TITLE
Replace javafx.util.Pair

### DIFF
--- a/jvm/src/test/java/com/nawforce/apexparser/ApexParserTest.java
+++ b/jvm/src/test/java/com/nawforce/apexparser/ApexParserTest.java
@@ -3,7 +3,9 @@ package com.nawforce.apexparser;
 import org.junit.jupiter.api.Test;
 
 import static com.nawforce.apexparser.ApexParserWithSyntaxErrorCounter.createParser;
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class ApexParserTest {
 
@@ -163,5 +165,3 @@ public class ApexParserTest {
         assertEquals(0, parserAndCounter.getNumErrors());
     }
 }
-
-

--- a/jvm/src/test/java/com/nawforce/apexparser/ApexParserTest.java
+++ b/jvm/src/test/java/com/nawforce/apexparser/ApexParserTest.java
@@ -2,167 +2,165 @@ package com.nawforce.apexparser;
 
 import org.junit.jupiter.api.Test;
 
-import javafx.util.Pair;
-
-import static com.nawforce.apexparser.SyntaxErrorCounter.createParser;
+import static com.nawforce.apexparser.ApexParserWithSyntaxErrorCounter.createParser;
 import static org.junit.jupiter.api.Assertions.*;
 
 public class ApexParserTest {
 
     @Test
     void testBooleanLiteral() {
-        Pair<ApexParser, SyntaxErrorCounter> parserAndCounter = createParser("true");
+        ApexParserWithSyntaxErrorCounter parserAndCounter = createParser("true");
 
-        ApexParser.LiteralContext context = parserAndCounter.getKey().literal();
+        ApexParser.LiteralContext context = parserAndCounter.getParser().literal();
         assertNotNull(context);
         assertEquals("true", context.BooleanLiteral().getText());
-        assertEquals(0, parserAndCounter.getValue().getNumErrors());
+        assertEquals(0, parserAndCounter.getNumErrors());
     }
 
     @Test
     void testExpression() {
-        Pair<ApexParser, SyntaxErrorCounter> parserAndCounter = createParser("a * 5");
-        ApexParser.ExpressionContext context = parserAndCounter.getKey().expression();
+        ApexParserWithSyntaxErrorCounter parserAndCounter = createParser("a * 5");
+        ApexParser.ExpressionContext context = parserAndCounter.getParser().expression();
         assertTrue(context instanceof ApexParser.Arth1ExpressionContext);
         assertEquals(2, ((ApexParser.Arth1ExpressionContext) context).expression().size());
     }
 
     @Test
     void testClass() {
-        Pair<ApexParser, SyntaxErrorCounter> parserAndCounter = createParser("public class Hello {}");
-        ApexParser.CompilationUnitContext context = parserAndCounter.getKey().compilationUnit();
+        ApexParserWithSyntaxErrorCounter parserAndCounter = createParser("public class Hello {}");
+        ApexParser.CompilationUnitContext context = parserAndCounter.getParser().compilationUnit();
         assertNotNull(context);
-        assertEquals(0, parserAndCounter.getValue().getNumErrors());
+        assertEquals(0, parserAndCounter.getNumErrors());
     }
 
     @Test
     void testCaseInsensitivity() {
-        Pair<ApexParser, SyntaxErrorCounter> parserAndCounter = createParser("Public CLASS Hello {}");
-        ApexParser.CompilationUnitContext context = parserAndCounter.getKey().compilationUnit();
+        ApexParserWithSyntaxErrorCounter parserAndCounter = createParser("Public CLASS Hello {}");
+        ApexParser.CompilationUnitContext context = parserAndCounter.getParser().compilationUnit();
         assertNotNull(context);
-        assertEquals(0, parserAndCounter.getValue().getNumErrors());
+        assertEquals(0, parserAndCounter.getNumErrors());
     }
 
     @Test
     void testClassWithError() {
-        Pair<ApexParser, SyntaxErrorCounter> parserAndCounter = createParser("public class Hello {");
-        ApexParser.CompilationUnitContext context = parserAndCounter.getKey().compilationUnit();
+        ApexParserWithSyntaxErrorCounter parserAndCounter = createParser("public class Hello {");
+        ApexParser.CompilationUnitContext context = parserAndCounter.getParser().compilationUnit();
         assertNotNull(context);
-        assertEquals(1, parserAndCounter.getValue().getNumErrors());
+        assertEquals(1, parserAndCounter.getNumErrors());
     }
 
     @Test
     void testClassWithSOQL() {
-        Pair<ApexParser, SyntaxErrorCounter> parserAndCounter = createParser(
+        ApexParserWithSyntaxErrorCounter parserAndCounter = createParser(
                 "public class Hello {\n" +
                         "        public void func() {\n" +
                         "            List<Account> accounts = [Select Id from Accounts];\n" +
                         "        }\n" +
                         "    }");
-        ApexParser.CompilationUnitContext context = parserAndCounter.getKey().compilationUnit();
+        ApexParser.CompilationUnitContext context = parserAndCounter.getParser().compilationUnit();
         assertNotNull(context);
-        assertEquals(0, parserAndCounter.getValue().getNumErrors());
+        assertEquals(0, parserAndCounter.getNumErrors());
     }
 
     @Test
     void testTrigger() {
-        Pair<ApexParser, SyntaxErrorCounter> parserAndCounter = createParser("trigger test on Account (before update, after update) {}");
-        ApexParser.TriggerUnitContext context = parserAndCounter.getKey().triggerUnit();
+        ApexParserWithSyntaxErrorCounter parserAndCounter = createParser("trigger test on Account (before update, after update) {}");
+        ApexParser.TriggerUnitContext context = parserAndCounter.getParser().triggerUnit();
         assertNotNull(context);
-        assertEquals(0, parserAndCounter.getValue().getNumErrors());
+        assertEquals(0, parserAndCounter.getNumErrors());
     }
 
     @Test
     void testSOQL() {
-        Pair<ApexParser, SyntaxErrorCounter> parserAndCounter = createParser("Select Fields(All) from Account");
-        ApexParser.QueryContext context = parserAndCounter.getKey().query();
+        ApexParserWithSyntaxErrorCounter parserAndCounter = createParser("Select Fields(All) from Account");
+        ApexParser.QueryContext context = parserAndCounter.getParser().query();
         assertNotNull(context);
-        assertEquals(0, parserAndCounter.getValue().getNumErrors());
+        assertEquals(0, parserAndCounter.getNumErrors());
     }
 
     @Test
     void testCurrencyLiteral() {
-        Pair<ApexParser, SyntaxErrorCounter> parserAndCounter = createParser(
+        ApexParserWithSyntaxErrorCounter parserAndCounter = createParser(
                 "SELECT Id FROM Account WHERE Amount > USD100.01 AND Amount < USD200");
-        ApexParser.QueryContext context = parserAndCounter.getKey().query();
+        ApexParser.QueryContext context = parserAndCounter.getParser().query();
         assertNotNull(context);
-        assertEquals(0, parserAndCounter.getValue().getNumErrors());
+        assertEquals(0, parserAndCounter.getNumErrors());
     }
 
     @Test
     void testIdentifiersThatCouldBeCurrencyLiterals() {
-        Pair<ApexParser, SyntaxErrorCounter> parserAndCounter = createParser(
+        ApexParserWithSyntaxErrorCounter parserAndCounter = createParser(
                 "USD100.name = 'name';");
-        ApexParser.StatementContext context = parserAndCounter.getKey().statement();
+        ApexParser.StatementContext context = parserAndCounter.getParser().statement();
         assertNotNull(context);
-        assertEquals(0, parserAndCounter.getValue().getNumErrors());
+        assertEquals(0, parserAndCounter.getNumErrors());
     }
 
     @Test
     void testDateTimeLiteral() {
-        Pair<ApexParser, SyntaxErrorCounter> parserAndCounter = createParser(
+        ApexParserWithSyntaxErrorCounter parserAndCounter = createParser(
                 "SELECT Name, (SELECT Id FROM Account WHERE createdDate > 2020-01-01T12:00:00Z) FROM Opportunity");
-        ApexParser.QueryContext context = parserAndCounter.getKey().query();
+        ApexParser.QueryContext context = parserAndCounter.getParser().query();
         assertNotNull(context);
-        assertEquals(0, parserAndCounter.getValue().getNumErrors());
+        assertEquals(0, parserAndCounter.getNumErrors());
     }
 
     @Test
     void testNegativeNumericLiteral() {
-        Pair<ApexParser, SyntaxErrorCounter> parserAndCounter = createParser(
+        ApexParserWithSyntaxErrorCounter parserAndCounter = createParser(
                 "SELECT Name FROM Opportunity WHERE Value = -100.123");
-        ApexParser.QueryContext context = parserAndCounter.getKey().query();
+        ApexParser.QueryContext context = parserAndCounter.getParser().query();
         assertNotNull(context);
-        assertEquals(0, parserAndCounter.getValue().getNumErrors());
+        assertEquals(0, parserAndCounter.getNumErrors());
     }
 
     @Test
     void testLastQuarterKeyword() {
-        Pair<ApexParser, SyntaxErrorCounter> parserAndCounter = createParser(
+        ApexParserWithSyntaxErrorCounter parserAndCounter = createParser(
                 "SELECT Id FROM Account WHERE DueDate = LAST_QUARTER");
-        ApexParser.QueryContext context = parserAndCounter.getKey().query();
+        ApexParser.QueryContext context = parserAndCounter.getParser().query();
         assertNotNull(context);
-        assertEquals(0, parserAndCounter.getValue().getNumErrors());
+        assertEquals(0, parserAndCounter.getNumErrors());
     }
 
     @Test
     void testSemiAllowedAsWhileBody() {
-        Pair<ApexParser, SyntaxErrorCounter> parserAndCounter = createParser(
+        ApexParserWithSyntaxErrorCounter parserAndCounter = createParser(
                 "while (x++ < 10 && !(y-- < 0));");
-        ApexParser.StatementContext context = parserAndCounter.getKey().statement();
+        ApexParser.StatementContext context = parserAndCounter.getParser().statement();
         assertNotNull(context);
-        assertEquals(0, parserAndCounter.getValue().getNumErrors());
+        assertEquals(0, parserAndCounter.getNumErrors());
     }
 
     @Test
     void testSemiAllowedAsForBody() {
-        Pair<ApexParser, SyntaxErrorCounter> parserAndCounter = createParser(
+        ApexParserWithSyntaxErrorCounter parserAndCounter = createParser(
                 "for(x=0; x<10; x++);");
-        ApexParser.StatementContext context = parserAndCounter.getKey().statement();
+        ApexParser.StatementContext context = parserAndCounter.getParser().statement();
         assertNotNull(context);
-        assertEquals(0, parserAndCounter.getValue().getNumErrors());
+        assertEquals(0, parserAndCounter.getNumErrors());
     }
 
     @Test
     void testSemiDisallowedAsGeneralStatement() {
-        Pair<ApexParser, SyntaxErrorCounter> parserAndCounter = createParser(
+        ApexParserWithSyntaxErrorCounter parserAndCounter = createParser(
                 "if (x == 3); else { ; }");
-        ApexParser.StatementContext context = parserAndCounter.getKey().statement();
+        ApexParser.StatementContext context = parserAndCounter.getParser().statement();
         assertNotNull(context);
-        assertEquals(1, parserAndCounter.getValue().getNumErrors());
+        assertEquals(1, parserAndCounter.getNumErrors());
     }
 
     @Test
     void testWhenLiteralParens() {
-        Pair<ApexParser, SyntaxErrorCounter> parserAndCounter = createParser(
+        ApexParserWithSyntaxErrorCounter parserAndCounter = createParser(
                 "switch on (x) { \n" +
                         "  when 1 { return 1; } \n" +
                         "  when ((2)) { return 2; } \n" +
                         "  when (3), (4) { return 3; } \n" +
                         "}");
-        ApexParser.StatementContext context = parserAndCounter.getKey().statement();
+        ApexParser.StatementContext context = parserAndCounter.getParser().statement();
         assertNotNull(context);
-        assertEquals(0, parserAndCounter.getValue().getNumErrors());
+        assertEquals(0, parserAndCounter.getNumErrors());
     }
 }
 

--- a/jvm/src/test/java/com/nawforce/apexparser/ApexParserWithSyntaxErrorCounter.java
+++ b/jvm/src/test/java/com/nawforce/apexparser/ApexParserWithSyntaxErrorCounter.java
@@ -1,10 +1,19 @@
 package com.nawforce.apexparser;
 
-import javafx.util.Pair;
-import org.antlr.v4.runtime.*;
+import org.antlr.v4.runtime.CharStreams;
+import org.antlr.v4.runtime.CommonTokenStream;
+import org.antlr.v4.runtime.BaseErrorListener;
+import org.antlr.v4.runtime.RecognitionException;
+import org.antlr.v4.runtime.Recognizer;
 
-public class SyntaxErrorCounter extends BaseErrorListener {
+public class ApexParserWithSyntaxErrorCounter extends BaseErrorListener {
     private int numErrors = 0;
+    private ApexParser parser;
+
+    ApexParserWithSyntaxErrorCounter(ApexParser parser) {
+      this.parser = parser;
+      parser.addErrorListener(this);
+    }
 
     @Override
     public void syntaxError(
@@ -21,15 +30,15 @@ public class SyntaxErrorCounter extends BaseErrorListener {
         return this.numErrors;
     }
 
-    public static Pair<ApexParser, SyntaxErrorCounter> createParser(String input) {
+    public ApexParser getParser() {
+        return parser;
+    }
+
+    public static ApexParserWithSyntaxErrorCounter createParser(String input) {
         ApexLexer lexer = new ApexLexer(new CaseInsensitiveInputStream(CharStreams.fromString(input)));
         CommonTokenStream tokens = new CommonTokenStream(lexer);
         ApexParser parser = new ApexParser(tokens);
-
         parser.removeErrorListeners();
-        SyntaxErrorCounter errorCounter = new SyntaxErrorCounter();
-        parser.addErrorListener(errorCounter);
-
-        return new Pair<>(parser, errorCounter);
+        return new ApexParserWithSyntaxErrorCounter(parser);
     }
 }

--- a/jvm/src/test/java/com/nawforce/apexparser/ApexParserWithSyntaxErrorCounter.java
+++ b/jvm/src/test/java/com/nawforce/apexparser/ApexParserWithSyntaxErrorCounter.java
@@ -1,8 +1,8 @@
 package com.nawforce.apexparser;
 
+import org.antlr.v4.runtime.BaseErrorListener;
 import org.antlr.v4.runtime.CharStreams;
 import org.antlr.v4.runtime.CommonTokenStream;
-import org.antlr.v4.runtime.BaseErrorListener;
 import org.antlr.v4.runtime.RecognitionException;
 import org.antlr.v4.runtime.Recognizer;
 

--- a/jvm/src/test/java/com/nawforce/apexparser/SOSLParserTest.java
+++ b/jvm/src/test/java/com/nawforce/apexparser/SOSLParserTest.java
@@ -2,49 +2,47 @@ package com.nawforce.apexparser;
 
 import org.junit.jupiter.api.Test;
 
-import javafx.util.Pair;
-
-import static com.nawforce.apexparser.SyntaxErrorCounter.createParser;
+import static com.nawforce.apexparser.ApexParserWithSyntaxErrorCounter.createParser;
 import static org.junit.jupiter.api.Assertions.*;
 
 public class SOSLParserTest {
     @Test
     void testBasicQuery() {
-        Pair<ApexParser, SyntaxErrorCounter> parserAndCounter = createParser("[Find 'something' RETURNING Account]");
-        ApexParser.SoslLiteralContext context = parserAndCounter.getKey().soslLiteral();
+        ApexParserWithSyntaxErrorCounter parserAndCounter = createParser("[Find 'something' RETURNING Account]");
+        ApexParser.SoslLiteralContext context = parserAndCounter.getParser().soslLiteral();
         assertNotNull(context);
-        assertEquals(0, parserAndCounter.getValue().getNumErrors());
+        assertEquals(0, parserAndCounter.getNumErrors());
     }
 
     @Test
     void testEmbeddedQuote() {
-        Pair<ApexParser, SyntaxErrorCounter> parserAndCounter = createParser("[Find 'some\\'thing' RETURNING Account]");
-        ApexParser.SoslLiteralContext context = parserAndCounter.getKey().soslLiteral();
+        ApexParserWithSyntaxErrorCounter parserAndCounter = createParser("[Find 'some\\'thing' RETURNING Account]");
+        ApexParser.SoslLiteralContext context = parserAndCounter.getParser().soslLiteral();
         assertNotNull(context);
-        assertEquals(0, parserAndCounter.getValue().getNumErrors());
+        assertEquals(0, parserAndCounter.getNumErrors());
     }
 
     @Test
     void testBracesFail() {
-        Pair<ApexParser, SyntaxErrorCounter> parserAndCounter = createParser("[Find {something} RETURNING Account]");
-        ApexParser.SoslLiteralContext context = parserAndCounter.getKey().soslLiteral();
+        ApexParserWithSyntaxErrorCounter parserAndCounter = createParser("[Find {something} RETURNING Account]");
+        ApexParser.SoslLiteralContext context = parserAndCounter.getParser().soslLiteral();
         assertNotNull(context);
-        assertEquals(1, parserAndCounter.getValue().getNumErrors());
+        assertEquals(1, parserAndCounter.getNumErrors());
     }
 
     @Test
     void testBracesOnAltFormat() {
-        Pair<ApexParser, SyntaxErrorCounter> parserAndCounter = createParser("[Find {something} RETURNING Account]");
-        ApexParser.SoslLiteralAltContext context = parserAndCounter.getKey().soslLiteralAlt();
+        ApexParserWithSyntaxErrorCounter parserAndCounter = createParser("[Find {something} RETURNING Account]");
+        ApexParser.SoslLiteralAltContext context = parserAndCounter.getParser().soslLiteralAlt();
         assertNotNull(context);
-        assertEquals(0, parserAndCounter.getValue().getNumErrors());
+        assertEquals(0, parserAndCounter.getNumErrors());
     }
 
     @Test
     void testQuotesFailOnAltFormat() {
-        Pair<ApexParser, SyntaxErrorCounter> parserAndCounter = createParser("[Find 'something' RETURNING Account]");
-        ApexParser.SoslLiteralAltContext context = parserAndCounter.getKey().soslLiteralAlt();
+        ApexParserWithSyntaxErrorCounter parserAndCounter = createParser("[Find 'something' RETURNING Account]");
+        ApexParser.SoslLiteralAltContext context = parserAndCounter.getParser().soslLiteralAlt();
         assertNotNull(context);
-        assertEquals(1, parserAndCounter.getValue().getNumErrors());
+        assertEquals(1, parserAndCounter.getNumErrors());
     }
 }

--- a/jvm/src/test/java/com/nawforce/apexparser/SOSLParserTest.java
+++ b/jvm/src/test/java/com/nawforce/apexparser/SOSLParserTest.java
@@ -3,7 +3,8 @@ package com.nawforce.apexparser;
 import org.junit.jupiter.api.Test;
 
 import static com.nawforce.apexparser.ApexParserWithSyntaxErrorCounter.createParser;
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 public class SOSLParserTest {
     @Test


### PR DESCRIPTION
As of Java 11, JavaFX has been decoupled from the JDK, and this class is not available.

It is available as an additional maven artifact, and LMK if you prefer that over this solution.
