### PR TITLE
Make sed patch work on my system

### DIFF
--- a/npm/package.json
+++ b/npm/package.json
@@ -11,7 +11,7 @@
     "test": "jest --config jestconfig.json lib",
     "antlr4ts": "npm run antlr-build && npm run antlr-patch ",
     "antlr-build": "(cd antlr; antlr4ts -visitor -o ../src ApexLexer.g4 ApexParser.g4)",
-    "antlr-patch": "sed -i '' -e 's/public void clearCache() {.*}//g' src/ApexParser.ts && sed -i '' -e 's/public void clearCache() {.*}//g' src/ApexLexer.ts",
+    "antlr-patch": "sed -i -e 's/public void clearCache() {.*}//g' src/ApexParser.ts && sed -i -e 's/public void clearCache() {.*}//g' src/ApexLexer.ts",
     "check": "node -e require(\"./lib/index.js\").check()'"
   },
   "files": [


### PR DESCRIPTION
Issue:

The previous syntax results in...
```
apex-parser $ npm run build
<elided some steps>
> apex-parser@2.15.0 antlr-build /tmp/apex-parser/npm
> (cd antlr; antlr4ts -visitor -o ../src ApexLexer.g4 ApexParser.g4)

Generating file '/tmp/apex-parser/npm/antlr/../src/./ApexLexer.interp' for grammar 'ApexLexer.g4'
Generating file '/tmp/apex-parser/npm/antlr/../src/./ApexLexer.ts' for grammar 'ApexLexer.g4'
Generating file '/tmp/apex-parser/npm/antlr/../src/./ApexLexer.tokens' for grammar 'ApexLexer.g4'
Generating file '/tmp/apex-parser/npm/antlr/../src/./ApexParser.interp' for grammar 'ApexParser.g4'
Generating file '/tmp/apex-parser/npm/antlr/../src/./ApexParser.ts' for grammar 'ApexParser.g4'
Generating file '/tmp/apex-parser/npm/antlr/../src/./ApexParserListener.ts' for grammar 'ApexParser.g4'
Generating file '/tmp/apex-parser/npm/antlr/../src/./ApexParserVisitor.ts' for grammar 'ApexParser.g4'
Generating file '/tmp/apex-parser/npm/antlr/../src/./ApexParser.tokens' for grammar 'ApexParser.g4'

> apex-parser@2.15.0 antlr-patch /tmp/apex-parser/npm
> sed -i '' -e 's/public void clearCache() {.*}//g' src/ApexParser.ts && sed -i '' -e 's/public void clearCache() {.*}//g' src/ApexLexer.ts

sed: can't read : No such file or directory
```

