### PR TITLE
Support additional ApexDoc cases

### DIFF
--- a/antlr/ApexLexer.g4
+++ b/antlr/ApexLexer.g4
@@ -434,7 +434,7 @@ WS  :  [ \t\r\n\u000C]+ -> channel(WHITESPACE_CHANNEL)
     ;
 
 DOC_COMMENT
-    :   '/**' [\r\n] .*? '*/' -> channel(COMMENT_CHANNEL)
+    :   '/**' .*? '*/' -> channel(COMMENT_CHANNEL)
     ;
 
 COMMENT

--- a/jvm/src/test/java/com/nawforce/apexparser/ApexLexerTest.java
+++ b/jvm/src/test/java/com/nawforce/apexparser/ApexLexerTest.java
@@ -38,4 +38,36 @@ public class ApexLexerTest {
         CommonTokenStream tokens  = new CommonTokenStream(lexer);
         assertEquals(2, tokens.getNumberOfOnChannelTokens());
     }
+
+    @Test
+    void testMultilineApexDoc() throws IOException {
+        ApexLexer lexer = new ApexLexer(new CaseInsensitiveInputStream(new StringReader("/**\n * ApexDoc\n */\nclass Test {}")));
+        CommonTokenStream tokens  = new CommonTokenStream(lexer);
+        tokens.fill();
+        assertEquals(ApexLexer.DOC_COMMENT, tokens.get(0).getType());
+    }
+
+    @Test
+    void testExtraAsterisksApexDoc() throws IOException {
+        ApexLexer lexer = new ApexLexer(new CaseInsensitiveInputStream(new StringReader("/********\n * ApexDoc\n */\nclass Test {}")));
+        CommonTokenStream tokens  = new CommonTokenStream(lexer);
+        tokens.fill();
+        assertEquals(ApexLexer.DOC_COMMENT, tokens.get(0).getType());
+    }
+
+    @Test
+    void testSingleLineApexDoc() throws IOException {
+        ApexLexer lexer = new ApexLexer(new CaseInsensitiveInputStream(new StringReader("/** ApexDoc */ class Test {}")));
+        CommonTokenStream tokens  = new CommonTokenStream(lexer);
+        tokens.fill();
+        assertEquals(ApexLexer.DOC_COMMENT, tokens.get(0).getType());
+    }
+
+    @Test
+    void testRegularComment() throws IOException {
+        ApexLexer lexer = new ApexLexer(new CaseInsensitiveInputStream(new StringReader("/* regular */ class Test {}")));
+        CommonTokenStream tokens  = new CommonTokenStream(lexer);
+        tokens.fill();
+        assertEquals(ApexLexer.COMMENT, tokens.get(0).getType());
+    }
 }


### PR DESCRIPTION
There are several tests in PMD that expect single-line ApexDoc comments.

This also handles case where ApexDoc begins with e.g. /**************
See: https://github.com/SalesforceFoundation/ApexDoc

Add unit tests.