### PR TITLE
New user/system access-level syntax in SOQL and DML

### DIFF
--- a/antlr/ApexLexer.g4
+++ b/antlr/ApexLexer.g4
@@ -109,6 +109,10 @@ WITHOUT       : 'without';
 LIST          : 'list';
 MAP           : 'map';
 
+// DML keywords
+SYSTEM          : 'system';
+USER            : 'user';
+
 // Soql specific keywords
 SELECT          : 'select';
 COUNT           : 'count';
@@ -155,6 +159,8 @@ ABOVE           : 'above';
 BELOW           : 'below';
 ABOVE_OR_BELOW  : 'above_or_below';
 SECURITY_ENFORCED : 'security_enforced';
+SYSTEM_MODE     : 'system_mode';
+USER_MODE       : 'user_mode';
 REFERENCE       : 'reference';
 CUBE            : 'cube';
 FORMAT          : 'format';

--- a/antlr/ApexParser.g4
+++ b/antlr/ApexParser.g4
@@ -342,28 +342,32 @@ continueStatement
     : CONTINUE SEMI
     ;
 
+accessLevel
+    : AS (SYSTEM | USER)
+    ;
+
 insertStatement
-    : INSERT expression SEMI
+    : INSERT accessLevel? expression SEMI
     ;
 
 updateStatement
-    : UPDATE expression SEMI
+    : UPDATE accessLevel? expression SEMI
     ;
 
 deleteStatement
-    : DELETE expression SEMI
+    : DELETE accessLevel? expression SEMI
     ;
 
 undeleteStatement
-    : UNDELETE expression SEMI
+    : UNDELETE accessLevel? expression SEMI
     ;
 
 upsertStatement
-    : UPSERT expression qualifiedName? SEMI
+    : UPSERT accessLevel? expression qualifiedName? SEMI
     ;
 
 mergeStatement
-    : MERGE expression expression SEMI
+    : MERGE accessLevel? expression expression SEMI
     ;
 
 runAsStatement
@@ -686,6 +690,8 @@ signedNumber
 withClause
     : WITH DATA CATEGORY filteringExpression
     | WITH SECURITY_ENFORCED
+    | WITH SYSTEM_MODE
+    | WITH USER_MODE
     | WITH logicalExpression;
 
 filteringExpression
@@ -866,6 +872,9 @@ id
     | WHEN
     | WITH
     | WITHOUT
+    // DML Keywords
+    | USER
+    | SYSTEM
     // SOQL Values
     | IntegralCurrencyLiteral
     // SOQL Specific Keywords
@@ -914,6 +923,8 @@ id
     | BELOW
     | ABOVE_OR_BELOW
     | SECURITY_ENFORCED
+    | USER_MODE
+    | SYSTEM_MODE
     | REFERENCE
     | CUBE
     | FORMAT
@@ -1059,6 +1070,9 @@ anyId
     | WHILE
     | WITH
     | WITHOUT
+    // DML Keywords
+    | USER
+    | SYSTEM
     // SOQL Values
     | IntegralCurrencyLiteral
     // SOQL Specific Keywords
@@ -1107,6 +1121,8 @@ anyId
     | BELOW
     | ABOVE_OR_BELOW
     | SECURITY_ENFORCED
+    | SYSTEM_MODE
+    | USER_MODE
     | REFERENCE
     | CUBE
     | FORMAT

--- a/jvm/src/test/java/com/nawforce/apexparser/ApexParserTest.java
+++ b/jvm/src/test/java/com/nawforce/apexparser/ApexParserTest.java
@@ -164,6 +164,30 @@ public class ApexParserTest {
         assertNotNull(context);
         assertEquals(0, parserAndCounter.getValue().getNumErrors());
     }
+
+    @Test
+    void testSoqlModeKeywords() {
+        String [] MODES = new String[] { "USER_MODE", "SYSTEM_MODE" };
+        for (String mode : MODES) {
+            Map.Entry<ApexParser, SyntaxErrorCounter> parserAndCounter = createParser(
+                    String.format("SELECT Id FROM Account WITH %s", mode));
+            ApexParser.QueryContext context = parserAndCounter.getKey().query();
+            assertNotNull(context);
+            assertEquals(0, parserAndCounter.getValue().getNumErrors());
+        }
+    }
+
+    @Test
+    void testDmlModeKeywords() {
+        String [] MODES = new String[] { "USER", "SYSTEM" };
+        for (String mode : MODES) {
+            Map.Entry<ApexParser, SyntaxErrorCounter> parserAndCounter = createParser(
+                    String.format("insert as %s contact;", mode));
+            ApexParser.StatementContext context = parserAndCounter.getKey().statement();
+            assertNotNull(context);
+            assertEquals(0, parserAndCounter.getValue().getNumErrors());
+        }
+    }
 }
 
 


### PR DESCRIPTION
This adds grammar support for SOQL access mode, for example:

```
List<Account> acc1 = [SELECT Id FROM Account WITH USER_MODE];

List<Account> acc2 = [SELECT Id FROM Account WITH SYSTEM_MODE];
``` 

And for DML queries:

```
Account acc = new Account(Name='test');
insert as user acc;

insert as system acc;
```

https://developer.salesforce.com/docs/atlas.en-us.apexcode.meta/apexcode/apex_classes_enforce_usermode.htm

Add unit tests. Tested against internal codebase.
