### PR TITLE
Support null coalescing operator (Apex 60)

### DIFF
--- a/antlr/ApexLexer.g4
+++ b/antlr/ApexLexer.g4
@@ -367,7 +367,8 @@ SEMI            : ';';
 COMMA           : ',';
 DOT             : '.';
 
-// §3.12 Operators
+// §3.12 Operators (JLS https://docs.oracle.com/javase/specs/jls/se21/html/jls-3.html#jls-3.12)
+// https://developer.salesforce.com/docs/atlas.en-us.248.0.apexcode.meta/apexcode/langCon_apex_expressions_operators_precedence.htm
 
 ASSIGN          : '=';
 GT              : '>';
@@ -405,6 +406,10 @@ XOR_ASSIGN      : '^=';
 LSHIFT_ASSIGN   : '<<=';
 RSHIFT_ASSIGN   : '>>=';
 URSHIFT_ASSIGN  : '>>>=';
+
+// null coalescing operator
+// since Apex 60: https://developer.salesforce.com/docs/atlas.en-us.apexcode.meta/apexcode/langCon_apex_NullCoalescingOperator.htm
+DOUBLE_QUESTION : '??';
 
 //
 // Additional symbols not defined in the lexical specification

--- a/antlr/ApexParser.g4
+++ b/antlr/ApexParser.g4
@@ -474,6 +474,7 @@ expression
     | expression BITOR expression                                                                     # bitOrExpression
     | expression AND expression                                                                       # logAndExpression
     | expression OR expression                                                                        # logOrExpression
+    | expression DOUBLE_QUESTION expression                                                           # nullCoalescingExpression
     | <assoc=right> expression QUESTION expression COLON expression                                   # condExpression
     | <assoc=right> expression
       (   ASSIGN

--- a/jvm/src/test/java/com/nawforce/apexparser/ApexParserTest.java
+++ b/jvm/src/test/java/com/nawforce/apexparser/ApexParserTest.java
@@ -188,6 +188,14 @@ public class ApexParserTest {
             assertEquals(0, parserAndCounter.getValue().getNumErrors());
         }
     }
+
+    @Test
+    void testNullCoalescingOperator() {
+        Map.Entry<ApexParser, SyntaxErrorCounter> parserAndCounter = createParser("Integer notNullReturnValue = anInteger ?? 100;");
+        ApexParser.StatementContext context = parserAndCounter.getKey().statement();
+        assertNotNull(context);
+        assertEquals(0, parserAndCounter.getValue().getNumErrors());
+    }
 }
 
 

--- a/npm/src/__tests__/ApexParserTest.ts
+++ b/npm/src/__tests__/ApexParserTest.ts
@@ -218,3 +218,12 @@ test('testDmlModeKeywords', () => {
         expect(errorCounter.getNumErrors()).toEqual(0)
     }
 })
+
+test('testNullCoalescingOperator', () => {
+    const [parser, errorCounter] = createParser("test.apex", "Integer notNullReturnValue = anInteger ?? 100;");
+
+    const context = parser.statement()
+
+    expect(context).toBeInstanceOf(StatementContext)
+    expect(errorCounter.getNumErrors()).toEqual(0)
+})


### PR DESCRIPTION
This adds grammar support for the new null coalescing operator added with Apex 60:

https://developer.salesforce.com/docs/atlas.en-us.apexcode.meta/apexcode/langCon_apex_NullCoalescingOperator.htm

Example:

```java
Integer notNullReturnValue = anInteger ?? 100;
```

This is needed for https://github.com/pmd/pmd/issues/4828
